### PR TITLE
change return no read keys result

### DIFF
--- a/casestatus_dbcs.go
+++ b/casestatus_dbcs.go
@@ -78,9 +78,9 @@ func (c *RedisCallers) HasUnreadStatus(userId, corpId string) (bool, error) {
 
 	count := len(keys)
 	if count == 0 {
-		return false, nil
+		return true, nil
 	} else {
-		for _, k :=  range(keys) {
+		for _, k :=  range keys {
 			v, _ := c.Client.Get(k).Int()
 			if v == 0 {
 				return true, nil


### PR DESCRIPTION
* 另一个方法中如果caseReadstatus不存在redis中， 返回0（未读状态）。
* 判断是否有未读状态的case时，当count keys 为0时， 说明都是未读的，应该返回true
